### PR TITLE
DM:add support for offsets

### DIFF
--- a/Adafruit_ZeroDMA.h
+++ b/Adafruit_ZeroDMA.h
@@ -41,7 +41,9 @@ class Adafruit_ZeroDMA {
   // DMA descriptor functions
   DmacDescriptor *addDescriptor(void *src, void *dst, uint32_t count = 0,
                     dma_beat_size size = DMA_BEAT_SIZE_BYTE,
-                    bool srcInc = true, bool dstInc = true);
+                    bool srcInc = true, bool dstInc = true, 
+					uint32_t stepSize = DMA_ADDRESS_INCREMENT_STEP_SIZE_1, 
+					bool stepSel = DMA_STEPSEL_DST);
   void            changeDescriptor(DmacDescriptor *d, void *src = NULL,
                     void *dst = NULL, uint32_t count = 0);
 


### PR DESCRIPTION
Hey I've added support for step sizes to this lib. I was also having issues with the interrupts on the samd51 so I fixed that too.
The offset functionality is going to be used in the audio library when the provided data is interleaved LRLR:
https://github.com/adafruit/Audio/blob/master/output_dacs.cpp#L107
