### PR TITLE
include tinyusb header if selected

### DIFF
--- a/Adafruit_ZeroDMA.cpp
+++ b/Adafruit_ZeroDMA.cpp
@@ -30,6 +30,11 @@
 #include <malloc.h> // memalign() function
 #include <stdlib.h>
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB
+#include <Adafruit_TinyUSB.h>
+#endif
+
 #ifdef DMAC_RESERVED_CHANNELS // SAMD core > 1.2.1
 #include <dma.h> // _descriptor[] and _writeback[] are extern'd here
 static volatile uint32_t _channelMask = DMAC_RESERVED_CHANNELS;


### PR DESCRIPTION
This include TinyUSB header if selected via Menu. It doesn't look much but help to link TinyUSB whenever this zero_DMA is linked. The sketch that use zero DMA doesn't need to explicitly include TinyUSB header but still got the everything linked.

This will ease many of CI build

update: also add zero test only for examples/zerodma_adc since it doesn't build with M4