### PR TITLE
-removed the "weak" attribute from the alias DMAC handler functions

### DIFF
--- a/Adafruit_ZeroDMA.cpp
+++ b/Adafruit_ZeroDMA.cpp
@@ -144,10 +144,10 @@ void DMAC_Handler(void) {
 }
 
 #ifdef __SAMD51__
-void DMAC_1_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
-void DMAC_2_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
-void DMAC_3_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
-void DMAC_4_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
+void DMAC_1_Handler(void) __attribute__((alias("DMAC_0_Handler")));
+void DMAC_2_Handler(void) __attribute__((alias("DMAC_0_Handler")));
+void DMAC_3_Handler(void) __attribute__((alias("DMAC_0_Handler")));
+void DMAC_4_Handler(void) __attribute__((alias("DMAC_0_Handler")));
 #endif
 
 void Adafruit_ZeroDMA::_IRQhandler(uint8_t flags) {


### PR DESCRIPTION
As I added here: https://github.com/adafruit/Adafruit-GFX-Library/issues/349
I ran into an issue when compiling my own library using PlatformIO which depends on ZeroDMA for the ATSAMD51.

I further debugged the issue today and neither my breakpoint for the DMAC_0_Handler() or the IRQHandler() function was triggered.

Sandwiched in between I found this block:
#ifdef __SAMD51__
void DMAC_1_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
void DMAC_2_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
void DMAC_3_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
void DMAC_4_Handler(void) __attribute__((weak, alias("DMAC_0_Handler")));
#endif

And as stepped thru Adafruit_ZeroDMA::startJob I noticed that it configured an interrupt for DMA channel 2.
And still the interrupt triggered ended up in the default handler.

So I duplicated void DMAC_0_Handler(void), renamed it DMAC_2_Handler() and removed the alias line.
And it worked just fine.
Somehow the alias functions are not used when using ZeroDMA from another library.

Next I removed the "weak" attributes and now my code is running just fine.