### PR TITLE
feat(api): add methods to free DMA descriptors

### DIFF
--- a/Adafruit_ZeroDMA.cpp
+++ b/Adafruit_ZeroDMA.cpp
@@ -290,6 +290,51 @@ ZeroDMAstatus Adafruit_ZeroDMA::allocate(void) {
   return DMA_STATUS_OK;
 }
 
+ZeroDMAstatus Adafruit_ZeroDMA::freeChannel(void) {
+
+  while (DMA_STATUS_BUSY == jobStatus)
+    { yield(); } // Passively wait for job to finish
+
+  if (channel >= DMAC_CH_NUM)
+    { return DMA_STATUS_ERR_NOT_FOUND; } // Invalid channel
+
+  if (0 == (_channelMask & (1 << channel)))
+    { return DMA_STATUS_ERR_NOT_INITIALIZED; } // Channel not in use
+
+  cpu_irq_enter_critical();
+
+  _dmaPtr[channel] = NULL;           // Clear pointer
+  _channelMask &= ~(1 << channel);   // ...and bit.
+
+  if (!_channelMask) {
+    // No more channels in use, disable DMA IP
+#if (__SAMD51__)
+    NVIC_DisableIRQ(DMAC_0_IRQn); // Disable DMA interrupt
+    MCLK->AHBMASK.bit.DMAC_ = 0;  // Disable DMA clock
+#else
+    NVIC_DisableIRQ(DMAC_IRQn);   // Disable DMA interrupt
+    #if !(SAML21) && !(SAML22) && !(SAMC20) && !(SAMC21)
+    PM->APBBMASK.bit.DMAC_ = 0;   // Disable DMA clock (D21-only)
+    #endif
+    PM->AHBMASK.bit.DMAC_ = 0;    // Disable DMA clock
+#endif
+    DMAC->CTRL.bit.DMAENABLE = 0; // Disable DMA controller
+  }
+
+  // Finally, disable the channel
+#if (__SAMD51__)
+  DMAC->Channel[channel].CHCTRLA.bit.ENABLE = 0;
+#else
+  DMAC->CHID.bit.ID = channel;
+  DMAC->CHCTRLA.bit.ENABLE = 0;
+#endif
+
+  cpu_irq_leave_critical();
+
+  return DMA_STATUS_OK;
+}
+
+
 void Adafruit_ZeroDMA::setPriority(dma_priority pri) {
 #ifdef __SAMD51__
   DMAC->Channel[channel].CHPRILVL.bit.PRILVL = pri;
@@ -298,40 +343,14 @@ void Adafruit_ZeroDMA::setPriority(dma_priority pri) {
 #endif
 }
 
-// Deallocate DMA channel
-// TODO: should this delete/deallocate the descriptor list?
-ZeroDMAstatus Adafruit_ZeroDMA::free(void) {
-
-  ZeroDMAstatus status = DMA_STATUS_OK;
-
-  cpu_irq_enter_critical(); // jobStatus is volatile
-
-  if (jobStatus == DMA_STATUS_BUSY) {
-    status = DMA_STATUS_BUSY; // Can't leave when busy
-  } else if ((channel < DMAC_CH_NUM) && (_channelMask & (1 << channel))) {
-    // Valid in-use channel; release it
-    _channelMask &= ~(1 << channel); // Clear bit
-    if (!_channelMask) {             // No more channels in use?
-#ifdef __SAMD51__
-      NVIC_DisableIRQ(DMAC_0_IRQn); // Disable DMA interrupt
-      DMAC->CTRL.bit.DMAENABLE = 0; // Disable DMA
-      MCLK->AHBMASK.bit.DMAC_ = 0;  // Disable DMA clock
-#else
-      NVIC_DisableIRQ(DMAC_IRQn);   // Disable DMA interrupt
-      DMAC->CTRL.bit.DMAENABLE = 0; // Disable DMA
-      PM->APBBMASK.bit.DMAC_ = 0;   // Disable DMA clocks
-      PM->AHBMASK.bit.DMAC_ = 0;
-#endif
-    }
-    _dmaPtr[channel] = NULL;
-    channel = 0xFF;
-  } else {
-    status = DMA_STATUS_ERR_NOT_INITIALIZED; // Channel not in use
+// Deallocate DMA channel and, optionally, all associated descriptors.
+ZeroDMAstatus Adafruit_ZeroDMA::free(bool freeChannelAndDescriptors) {
+  if (freeChannelAndDescriptors) {
+    ZeroDMAstatus status = freeDescriptors();
+    if (status != DMA_STATUS_OK)
+      { return status; }
   }
-
-  cpu_irq_leave_critical();
-
-  return status;
+  return freeChannel();
 }
 
 // Start DMA transfer job.  Channel and descriptors should be allocated
@@ -634,7 +653,83 @@ void Adafruit_ZeroDMA::changeDescriptor(DmacDescriptor *desc, void *src,
 #endif
 }
 
-// TODO: delete descriptor, delete whole descriptor chain
+ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptor(DmacDescriptor *desc) {
+
+  while (DMA_STATUS_BUSY == jobStatus)
+    { yield(); } // Passively wait for job to finish
+
+  if (!hasDescriptors)
+    { return DMA_STATUS_ERR_NOT_INITIALIZED; } // No descriptors allocated
+
+  cpu_irq_enter_critical();
+
+  const uint32_t addr = (const uint32_t)(desc);
+
+  // Scan descriptor list to find entry with matching address
+  DmacDescriptor * const head = &_descriptor[channel];
+  DmacDescriptor *prev = head;
+  while (prev->DESCADDR.reg != addr) {
+    prev = (DmacDescriptor *)prev->DESCADDR.reg;
+    // End-of-list can be indicated by either:
+    //  a. prev.DESCADDR.reg == NULL               => un-looped list
+    //  b. prev.DESCADDR.reg == head.DESCADDR.reg  => looped list
+    if (!prev || prev == head) {
+      cpu_irq_leave_critical();
+      return DMA_STATUS_ERR_NOT_INITIALIZED; // Not found
+    }
+  }
+
+  // Found it; unlink from list
+  prev->DESCADDR.reg = desc->DESCADDR.reg;
+
+  // If this was the last descriptor in the list, clear the DESCADDR value to
+  // indicate an un-looped list.
+  if (prev == desc)
+    { head->DESCADDR.reg = 0; }
+
+  // Zero and free descriptor memory
+  memset(desc, 0, sizeof(*desc));
+  std::free(desc);
+
+  cpu_irq_leave_critical();
+
+  return DMA_STATUS_OK;
+}
+
+ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptors(void) {
+
+  while (DMA_STATUS_BUSY == jobStatus)
+    { yield(); } // Passively wait for job to finish
+
+  if (!hasDescriptors)
+    { return DMA_STATUS_ERR_NOT_INITIALIZED; } // No descriptors allocated
+
+  cpu_irq_enter_critical();
+
+  // Scan descriptor list to find last entry. If an entry's DESCADDR value is 0,
+  // that's the end of the list and it's currently un-looped. If the DESCADDR
+  // value is the same as the first entry, that's the end of the list and it's
+  // looped. Either way, set every entry's DESCADDR value to 0.
+  DmacDescriptor * const head = &_descriptor[channel];
+  DmacDescriptor *prev = head;
+  while (prev->DESCADDR.reg && prev->DESCADDR.reg != (uint32_t)head) {
+    DmacDescriptor *next = (DmacDescriptor *)prev->DESCADDR.reg;
+    memset(prev, 0, sizeof(*prev));
+    std::free(prev);
+    prev = next;
+  }
+  memset(prev, 0, sizeof(*prev));
+  std::free(prev);
+
+  memset(head, 0, sizeof(*head)); // Clear descriptor list head
+
+  hasDescriptors = false;
+
+  cpu_irq_leave_critical();
+
+  return DMA_STATUS_OK;
+}
+
 
 // Select whether channel's descriptor list should repeat or not.
 // This can be done before or after channel & any descriptors are allocated.

--- a/Adafruit_ZeroDMA.cpp
+++ b/Adafruit_ZeroDMA.cpp
@@ -292,19 +292,22 @@ ZeroDMAstatus Adafruit_ZeroDMA::allocate(void) {
 
 ZeroDMAstatus Adafruit_ZeroDMA::freeChannel(void) {
 
-  while (DMA_STATUS_BUSY == jobStatus)
-    { yield(); } // Passively wait for job to finish
+  while (DMA_STATUS_BUSY == jobStatus) {
+    yield();
+  } // Passively wait for job to finish
 
-  if (channel >= DMAC_CH_NUM)
-    { return DMA_STATUS_ERR_NOT_FOUND; } // Invalid channel
+  if (channel >= DMAC_CH_NUM) {
+    return DMA_STATUS_ERR_NOT_FOUND;
+  } // Invalid channel
 
-  if (0 == (_channelMask & (1 << channel)))
-    { return DMA_STATUS_ERR_NOT_INITIALIZED; } // Channel not in use
+  if (0 == (_channelMask & (1 << channel))) {
+    return DMA_STATUS_ERR_NOT_INITIALIZED;
+  } // Channel not in use
 
   cpu_irq_enter_critical();
 
-  _dmaPtr[channel] = NULL;           // Clear pointer
-  _channelMask &= ~(1 << channel);   // ...and bit.
+  _dmaPtr[channel] = NULL;         // Clear pointer
+  _channelMask &= ~(1 << channel); // ...and bit.
 
   if (!_channelMask) {
     // No more channels in use, disable DMA IP
@@ -312,11 +315,11 @@ ZeroDMAstatus Adafruit_ZeroDMA::freeChannel(void) {
     NVIC_DisableIRQ(DMAC_0_IRQn); // Disable DMA interrupt
     MCLK->AHBMASK.bit.DMAC_ = 0;  // Disable DMA clock
 #else
-    NVIC_DisableIRQ(DMAC_IRQn);   // Disable DMA interrupt
-    #if !(SAML21) && !(SAML22) && !(SAMC20) && !(SAMC21)
-    PM->APBBMASK.bit.DMAC_ = 0;   // Disable DMA clock (D21-only)
-    #endif
-    PM->AHBMASK.bit.DMAC_ = 0;    // Disable DMA clock
+    NVIC_DisableIRQ(DMAC_IRQn); // Disable DMA interrupt
+#if !(SAML21) && !(SAML22) && !(SAMC20) && !(SAMC21)
+    PM->APBBMASK.bit.DMAC_ = 0; // Disable DMA clock (D21-only)
+#endif
+    PM->AHBMASK.bit.DMAC_ = 0;  // Disable DMA clock
 #endif
     DMAC->CTRL.bit.DMAENABLE = 0; // Disable DMA controller
   }
@@ -334,7 +337,6 @@ ZeroDMAstatus Adafruit_ZeroDMA::freeChannel(void) {
   return DMA_STATUS_OK;
 }
 
-
 void Adafruit_ZeroDMA::setPriority(dma_priority pri) {
 #ifdef __SAMD51__
   DMAC->Channel[channel].CHPRILVL.bit.PRILVL = pri;
@@ -347,8 +349,9 @@ void Adafruit_ZeroDMA::setPriority(dma_priority pri) {
 ZeroDMAstatus Adafruit_ZeroDMA::free(bool freeChannelAndDescriptors) {
   if (freeChannelAndDescriptors) {
     ZeroDMAstatus status = freeDescriptors();
-    if (status != DMA_STATUS_OK)
-      { return status; }
+    if (status != DMA_STATUS_OK) {
+      return status;
+    }
   }
   return freeChannel();
 }
@@ -655,18 +658,20 @@ void Adafruit_ZeroDMA::changeDescriptor(DmacDescriptor *desc, void *src,
 
 ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptor(DmacDescriptor *desc) {
 
-  while (DMA_STATUS_BUSY == jobStatus)
-    { yield(); } // Passively wait for job to finish
+  while (DMA_STATUS_BUSY == jobStatus) {
+    yield();
+  } // Passively wait for job to finish
 
-  if (!hasDescriptors)
-    { return DMA_STATUS_ERR_NOT_INITIALIZED; } // No descriptors allocated
+  if (!hasDescriptors) {
+    return DMA_STATUS_ERR_NOT_INITIALIZED;
+  } // No descriptors allocated
 
   cpu_irq_enter_critical();
 
   const uint32_t addr = (const uint32_t)(desc);
 
   // Scan descriptor list to find entry with matching address
-  DmacDescriptor * const head = &_descriptor[channel];
+  DmacDescriptor *const head = &_descriptor[channel];
   DmacDescriptor *prev = head;
   while (prev->DESCADDR.reg != addr) {
     prev = (DmacDescriptor *)prev->DESCADDR.reg;
@@ -684,8 +689,9 @@ ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptor(DmacDescriptor *desc) {
 
   // If this was the last descriptor in the list, clear the DESCADDR value to
   // indicate an un-looped list.
-  if (prev == desc)
-    { head->DESCADDR.reg = 0; }
+  if (prev == desc) {
+    head->DESCADDR.reg = 0;
+  }
 
   // Zero and free descriptor memory
   memset(desc, 0, sizeof(*desc));
@@ -698,11 +704,13 @@ ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptor(DmacDescriptor *desc) {
 
 ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptors(void) {
 
-  while (DMA_STATUS_BUSY == jobStatus)
-    { yield(); } // Passively wait for job to finish
+  while (DMA_STATUS_BUSY == jobStatus) {
+    yield();
+  } // Passively wait for job to finish
 
-  if (!hasDescriptors)
-    { return DMA_STATUS_ERR_NOT_INITIALIZED; } // No descriptors allocated
+  if (!hasDescriptors) {
+    return DMA_STATUS_ERR_NOT_INITIALIZED;
+  } // No descriptors allocated
 
   cpu_irq_enter_critical();
 
@@ -710,7 +718,7 @@ ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptors(void) {
   // that's the end of the list and it's currently un-looped. If the DESCADDR
   // value is the same as the first entry, that's the end of the list and it's
   // looped. Either way, set every entry's DESCADDR value to 0.
-  DmacDescriptor * const head = &_descriptor[channel];
+  DmacDescriptor *const head = &_descriptor[channel];
   DmacDescriptor *prev = head;
   while (prev->DESCADDR.reg && prev->DESCADDR.reg != (uint32_t)head) {
     DmacDescriptor *next = (DmacDescriptor *)prev->DESCADDR.reg;
@@ -729,7 +737,6 @@ ZeroDMAstatus Adafruit_ZeroDMA::freeDescriptors(void) {
 
   return DMA_STATUS_OK;
 }
-
 
 // Select whether channel's descriptor list should repeat or not.
 // This can be done before or after channel & any descriptors are allocated.

--- a/Adafruit_ZeroDMA.h
+++ b/Adafruit_ZeroDMA.h
@@ -79,7 +79,24 @@ public:
             DMA_STATUS_BUSY if channel is busy (can't deallocate while in use).
             DMA_STATUS_ERR_NOT_INITIALIZED if channel isn't in use.
   */
-  ZeroDMAstatus free(void);
+  ZeroDMAstatus freeChannel(void);
+
+  /*!
+    @brief  Deallocates a previously-allocated DMA channel and, optionally,
+            all associated descriptors. By default, only the channel is
+            deallocated.
+
+    @param  freeChannelAndDescriptors  If true, deallocate the channel and all
+                                       associated descriptors.
+                                       If false (default), deallocate only the
+                                       channel and leave descriptors unaffected.
+
+    @return ZeroDMAstatus type:
+            DMA_STATUS_OK on success.
+            DMA_STATUS_BUSY if channel is busy (can't deallocate while in use).
+            DMA_STATUS_ERR_NOT_INITIALIZED if channel isn't in use.
+  */
+  ZeroDMAstatus free(bool freeChannelAndDescriptors = false);
 
   /*!
     @brief  Activate a previously allocated-and-configured DMA channel's
@@ -218,6 +235,30 @@ public:
   */
   void changeDescriptor(DmacDescriptor *d, void *src = NULL, void *dst = NULL,
                         uint32_t count = 0);
+
+  /*!
+    @brief  Deallocates a previously-allocated DMA descriptor.
+            This deallocates the DESCRIPTOR, not any associated CHANNEL.
+
+    @param desc  Pointer to descriptor struct (as returned by addDescriptor()).
+
+    @return ZeroDMAstatus type:
+            DMA_STATUS_OK on success.
+            DMA_STATUS_BUSY if channel is busy (can't deallocate while in use).
+            DMA_STATUS_ERR_NOT_INITIALIZED if channel isn't in use.
+  */
+  ZeroDMAstatus freeDescriptor(DmacDescriptor *desc);
+
+  /*!
+    @brief  Deallocates all previously-allocated DMA descriptors.
+            This deallocates the DESCRIPTORS, not any associated CHANNEL.
+
+    @return ZeroDMAstatus type:
+            DMA_STATUS_OK on success.
+            DMA_STATUS_BUSY if channel is busy (can't deallocate while in use).
+            DMA_STATUS_ERR_NOT_INITIALIZED if channel isn't in use.
+  */
+  ZeroDMAstatus freeDescriptors(void);
 
   /*!
     @brief  Interrupt handler function, used internally by the library,


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  
The API prior this change only supports deallocating DMA channels (via method `(void)Adafruit_ZeroDMA::free(void)`), but it did not and **could not** deallocate the descriptor linked lists written to them. An _optional_ parameter was added to this method to also free the descriptor chain — but not by default — to retain backwards-compatibility.

- **Describe any known limitations with your change.**  
None

- **Please run any tests or examples that can exercise your modified code.**  
Verified examples `zerodma_spi1` and `zerodma_spi2` were functional on an ItsyBitsy M4
