### PR TITLE
[BUG] Fix busy status when callback not set

### DIFF
--- a/Adafruit_ZeroDMA.cpp
+++ b/Adafruit_ZeroDMA.cpp
@@ -306,7 +306,11 @@ ZeroDMAstatus Adafruit_ZeroDMA::free(void) {
 
   cpu_irq_enter_critical(); // jobStatus is volatile
 
-  if (jobStatus == DMA_STATUS_BUSY) {
+#ifdef __SAMD51__
+  if (DMAC->Channel[channel].CHSTATUS.reg & DMAC_CHSTATUS_BUSY) {
+#else
+  if (DMAC->CHSTATUS.reg & DMAC_CHSTATUS_BUSY) {
+#endif
     status = DMA_STATUS_BUSY; // Can't leave when busy
   } else if ((channel < DMAC_CH_NUM) && (_channelMask & (1 << channel))) {
     // Valid in-use channel; release it
@@ -341,7 +345,11 @@ ZeroDMAstatus Adafruit_ZeroDMA::startJob(void) {
 
   cpu_irq_enter_critical(); // Job status is volatile
 
-  if (jobStatus == DMA_STATUS_BUSY) {
+#ifdef __SAMD51__
+  if (DMAC->Channel[channel].CHSTATUS.reg & DMAC_CHSTATUS_BUSY) {
+#else
+  if (DMAC->CHSTATUS.reg & DMAC_CHSTATUS_BUSY) {
+#endif
     status = DMA_STATUS_BUSY; // Resource is busy
   } else if (channel >= DMAC_CH_NUM) {
     status = DMA_STATUS_ERR_NOT_INITIALIZED; // Channel not in use
@@ -495,7 +503,11 @@ DmacDescriptor *Adafruit_ZeroDMA::addDescriptor(void *src, void *dst,
     return NULL;
 
   // Can't do while job's busy
-  if (jobStatus == DMA_STATUS_BUSY)
+#ifdef __SAMD51__
+  if (DMAC->Channel[channel].CHSTATUS.reg & DMAC_CHSTATUS_BUSY)
+#else
+  if (DMAC->CHSTATUS.reg & DMAC_CHSTATUS_BUSY)
+#endif
     return NULL;
 
   DmacDescriptor *desc;

--- a/Adafruit_ZeroDMA.cpp
+++ b/Adafruit_ZeroDMA.cpp
@@ -502,7 +502,7 @@ DmacDescriptor *Adafruit_ZeroDMA::addDescriptor(void *src, void *dst,
   if (channel >= DMAC_CH_NUM)
     return NULL;
 
-  // Can't do while job's busy
+    // Can't do while job's busy
 #ifdef __SAMD51__
   if (DMAC->Channel[channel].CHSTATUS.reg & DMAC_CHSTATUS_BUSY)
 #else


### PR DESCRIPTION
- **Describe what this PR does**
  This PR fixes a bug that occurs when no callback is set. The job status is stuck at `busy`, even if the job is finished, rendering the DMA module unusable. This PR corrects that and allow DMA to function correctly.

- **Describe the scope of your change**
  This pull request changes the way it checks current status. Instead of checking `jobStatus`, it reads the status registers directly

- **Describe any known limitations with your change.**  
  None


closes #17 